### PR TITLE
Отключение компонента для консольного приложения

### DIFF
--- a/Yii2Debug.php
+++ b/Yii2Debug.php
@@ -50,7 +50,7 @@ class Yii2Debug extends CApplicationComponent
 	public function init()
 	{
 		parent::init();
-		if (!$this->enabled) return;
+		if (!$this->enabled || Yii::app() instanceof CConsoleApplication) return;
 
 		Yii::setPathOfAlias('yii2-debug', dirname(__FILE__));
 		Yii::app()->setImport(array(


### PR DESCRIPTION
При использовании компонента в общей конфигурации большого проекта - лучше стоит предусмотреть и останавливать инициализацию компонента в консольном приложении.
