### PR TITLE
Если jQuery подключается после Bootstrap, то Bootstrap не работает

### DIFF
--- a/Yii2DebugPanel.php
+++ b/Yii2DebugPanel.php
@@ -169,8 +169,6 @@ HTML;
 			);
 		}
 
-		Yii::app()->getClientScript()->registerScript(__CLASS__.'#'.$id, "jQuery('$id').tab();");
-
 		return <<<HTML
 <ul id="tabs{$counter}" class="nav nav-tabs">$tabs</ul>
 <div class="tab-content">$details</div>

--- a/views/layouts/main.php
+++ b/views/layouts/main.php
@@ -8,7 +8,7 @@ $assetUrl = CHtml::asset(Yii::getPathOfAlias('debug.assets'));
 /* @var CClientScript $cs */
 $cs = Yii::app()->getClientScript();
 $cs->registerCoreScript('jquery');
-$cs->registerScriptFile($assetUrl . '/js/bootstrap.js');
+$cs->registerScriptFile($assetUrl . '/js/bootstrap.js', CClientScript::POS_END);
 ?>
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<?php echo Yii::app()->language; ?>" lang="<?php echo Yii::app()->language; ?>">


### PR DESCRIPTION
Я указал по умолчанию `CClientScript::POS_END` для регистрации `bootstrap.js`. Это может возникнуть, если jQuery инициализируется в конце страницы. А также убрал скрипт для инициализации табов, в Bootstrap они по умолчанию иницилизаруются благодаря `data-toggle`.
