### PR TITLE
Request Panel: moduleId if exists

### DIFF
--- a/panels/Yii2RequestPanel.php
+++ b/panels/Yii2RequestPanel.php
@@ -60,7 +60,7 @@ class Yii2RequestPanel extends Yii2DebugPanel
 			if (!$actionID) $actionID = $controller->defaultAction;
 			if (($a = $controller->createAction($actionID)) !== null) {
 				if ($a instanceof CInlineAction) {
-					$action = get_class($controller) . '::action' . ucfirst($actionID) . '()';
+					$action = ( isset($controller->module->id)?$controller->module->id . ' @ ' : '' ) . get_class($controller) . '::action' . ucfirst($actionID) . '()';
 				} else {
 					$action = get_class($a) . '::run()';
 				}


### PR DESCRIPTION
Почему бы не отображать модуль (protected/modules) если есть информация о нём?
