### PR TITLE
Issue https://github.com/zhuravljov/yii2-debug/issues/15 fix

### DIFF
--- a/Yii2DebugModule.php
+++ b/Yii2DebugModule.php
@@ -21,6 +21,22 @@ class Yii2DebugModule extends CWebModule
 			Yii::app()->setComponents(array('viewRenderer' => array('enabled' => false)), false);
 			// Сброс скрипта для вывода тулбара
 			Yii::app()->getClientScript()->reset();
+
+			/**
+			 * Fixes https://github.com/zhuravljov/yii2-debug/issues/15 issue
+			 * Clears client script map defined in app config
+			 * and thus makes yii2-debug independent on config manipulations with jquery or bootstrap files
+			 * 'clientScript' => array(
+			 *      'scriptMap' => array(
+			 *          'jquery.js' => false
+			 *          'bootstrap.min.css' => false,
+			 *          'bootstrap.min.js' => false,
+			 *          'bootstrap-yii.css' => false
+			 *      )
+			 * )
+			 */
+			Yii::app()->getClientScript()->scriptMap = array();
+
 			return true;
 		}
 		else


### PR DESCRIPTION
Если  в scriptMap поставить 'jquery.js' => false и у себя в коде подключать jquery напрямую в html, то jquery не подгрузится если открыть панели тулбара. Все показал на скринах.
![bootstrap](https://cloud.githubusercontent.com/assets/3856071/4023252/b9bc4458-2b81-11e4-94c3-a516ba907a13.png)
![jquery](https://cloud.githubusercontent.com/assets/3856071/4023253/b9c1d1b6-2b81-11e4-8afe-77f48e1fe366.png)

если же почистить скриптмап уже в самом дебаге то все ок.
