### PR TITLE
- yii2-debug for yii 1.1.16

### DIFF
--- a/Yii2Debug.php
+++ b/Yii2Debug.php
@@ -44,6 +44,10 @@ class Yii2Debug extends CApplicationComponent
 	 */
 	public $enabled = true;
 	/**
+	 * @var bool show/hide toolbar in page.
+	 */
+	public $viewToolbar = true;
+	/**
 	 * @var string module ID for viewing stored debug logs.
 	 */
 	public $moduleId = 'debug';
@@ -111,8 +115,10 @@ class Yii2Debug extends CApplicationComponent
 			Yii::app()->getUrlManager()->addRules($rules, false);
 		}
 
-		Yii::app()->attachEventHandler('onEndRequest', array($this, 'onEndRequest'));
-		$this->initToolbar();
+		Yii::getLogger()->attachEventHandler('onFlush', array($this, 'onLogFlush'));
+
+		if ($this->viewToolbar)
+			$this->initToolbar();
 	}
 
 	/**
@@ -203,7 +209,7 @@ JS
 	/**
 	 * @param CEvent $event
 	 */
-	protected function onEndRequest($event)
+	protected function onLogFlush($event)
 	{
 		$this->processDebug();
 	}

--- a/Yii2DebugModule.php
+++ b/Yii2DebugModule.php
@@ -16,7 +16,7 @@ class Yii2DebugModule extends CWebModule
 			$this->owner->checkAccess()
 		) {
 			// Отключение дебагера на страницах просмотра ранее сохраненных логов
-			Yii::app()->detachEventHandler('onEndRequest', array($this->owner, 'onEndRequest'));
+			Yii::getLogger()->detachEventHandler('onFlush', array($this->owner, 'onLogFlush'));
 			// Отключение сторонних шаблонизаторов
 			Yii::app()->setComponents(array('viewRenderer' => array('enabled' => false)), false);
 			// Сброс скрипта для вывода тулбара

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,6 @@
 	],
 	"require": {
 		"php": ">=5.1.0",
-		"yiisoft/yii": ">=1.1.15"
+		"yiisoft/yii": ">=1.1.16"
 	}
 }


### PR DESCRIPTION
- yii2-debug for yii 1.1.16.
- flag for toolbar. 
Без поддержки младших версий, но и без зависимостей. Для того чтобы поддерживать младшие версии достаточно буде добавить два метода в Yii2Debug - attachHandler и detachHandler в которых будет элементарная проверка версии framework-а. И в зависимости от нее подписываться на тот или иной обработчик.